### PR TITLE
Make log_exec return the value of the command being logged, not tee.

### DIFF
--- a/logging.sh
+++ b/logging.sh
@@ -4,7 +4,7 @@ LOG_FILE=$(pwd)/install-$DATE.log
 
 log_exec() {
    "$@" | tee -a $LOG_FILE 2>&1
-   RET=$?
+   RET=${PIPESTATUS[0]}
    return $RET
 }
 


### PR DESCRIPTION
This was getting in the way of testing #12 and is a general bug.