### PR TITLE
Generate startup script before running buildapp.

### DIFF
--- a/mobileclient.sh
+++ b/mobileclient.sh
@@ -199,13 +199,6 @@ install_mwc() {
 
     log_exec sudo chown -R xtuple.xtuple /etc/xtuple
 
-    log_exec sudo su - xtuple -c "cd $XTDIR && ./scripts/build_app.js -c /etc/xtuple/$MWCVERSION/"$MWCNAME"/config.js"
-    RET=$?
-    if [ $RET -ne 0 ]; then
-        log "buildapp failed to run. Check output and try again"
-        do_exit
-    fi
-
     # bring on systemd please.. but until then
     if [ $DISTRO = "ubuntu" ]; then
         log "Creating upstart script using filename /etc/init/xtuple-"$MWCNAME".conf"
@@ -226,7 +219,14 @@ install_mwc() {
         log "well, in the node-datasource dir, type node main.js -c /etc/init/xtuple-\"$MWCNAME\".conf and cross your fingers."
         do_exit
     fi
-    
+
+    log_exec sudo su - xtuple -c "cd $XTDIR && ./scripts/build_app.js -c /etc/xtuple/$MWCVERSION/"$MWCNAME"/config.js"
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        log "buildapp failed to run. Check output and try again"
+        do_exit
+    fi
+
     # now that we have the script, start the server!
     log_exec sudo service xtuple-"$MWCNAME" start
 


### PR DESCRIPTION
@xtpclark suggested rearranging this bit of code.
> pclark: reason is - if buildapp fails - and I have to run it manually - I am without a startup script...